### PR TITLE
Add option to limit the number of columns in mismatch report

### DIFF
--- a/bin/get_blastn_report.py
+++ b/bin/get_blastn_report.py
@@ -51,7 +51,7 @@ REGEX_UNALLOWED_EXCEL_WS_CHARS = re.compile(r"[\\:/?*\[\]]+")
 @click.command()
 @click.option("-x", "--excel-report", default="report.xlsx", help="Excel report")
 @click.option('--min-aln-length', default=50, help="Min BLAST alignment length threshold")
-@click.option('--max-mismatch-report', default=80, help="Report Columns which have total mismatch < max-mismatch")
+@click.option('--max-mismatch-report', default=80, help="Report Columns which have total mismatch < max-mismatch-report")
 @click.option("-b", "--blast_results", default="", help="Blast Result.")
 def report(blast_results, excel_report, min_aln_length, max_mismatch_report):
     from rich.traceback import install

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -227,7 +227,13 @@ Minimum number of raw reads required per sample in order to be considered for th
 - Type: integer
 - Default: `700`
 
-Minimum alignment length of nucleotide BLAST results to consider for getting mismatch report from BLAST result against reference database. We normally set this number around the smallest genome segment (Segment 8)
+#### `--max_mismatch_report`
+
+- Optional
+- Type: integer
+- Default: `700`
+
+Report Columns which have total mismatch < max_mismatch_report
 
 ### H/N subtyping options
 

--- a/modules/local/blastn_report.nf
+++ b/modules/local/blastn_report.nf
@@ -27,6 +27,7 @@ process BLASTN_REPORT {
   get_blastn_report.py \\
    -b $blastn_results \\
    --min-aln-length ${params.min_aln_length} \\
+   --max-mismatch-report ${params.max_mismatch_report} \\
    -x ${meta.id}-blastn-report.xlsx
   ln -s .command.log get_blastn_report.log
   cat <<-END_VERSIONS > versions.yml

--- a/nextflow.config
+++ b/nextflow.config
@@ -22,6 +22,7 @@ params {
   pident_threshold                  = 0.85
   min_aln_length                    = 700
   max_top_blastn                    = 3
+  max_mismatch_report               = 80
   // reference data
   ncbi_influenza_fasta              = 'https://ftp.ncbi.nih.gov/genomes/INFLUENZA/influenza.fna.gz'
   ncbi_influenza_metadata           = 'https://ftp.ncbi.nih.gov/genomes/INFLUENZA/genomeset.dat.gz'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -180,6 +180,13 @@
                     "description": "Minimum alignment length of nucleotide BLAST results to consider for getting mismatch report from BLAST result against reference database. We normally set this number around the smallest genome segment (Segment 8).",
                     "fa_icon": "fas fa-balance-scale-right",
                     "minimum": 0
+                },
+                "max_mismatch_report": {
+                    "type": "integer",
+                    "default": 80,
+                    "description": "Report Columns which have total mismatch < max_mismatch_report",
+                    "fa_icon": "fas fa-balance-scale-right",
+                    "minimum": 0
                 }
             },
             "fa_icon": "fas fa-retweet"


### PR DESCRIPTION
Add option `--max-mismatch-report` when we have a large number of user sequences

<!--
# CFIA-NCFAD/nf-flu pull request

Many thanks for contributing to CFIA-NCFAD/nf-flu!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/CFIA-NCFAD/nf-flu/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/CFIA-NCFAD/nf-flu/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on [the CFIA-NCFAD/nf-test-datasets repo](https://github.com/CFIA-NCFAD/nf-test-datasets/pull/new)
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
