### PR TITLE
Fixed Bug: handle subtype in lower case

### DIFF
--- a/bin/parse_influenza_blast_results.py
+++ b/bin/parse_influenza_blast_results.py
@@ -222,11 +222,9 @@ def parse_blast_result(
         "category"
     )
     df_filtered["sample_segment"] = pd.Categorical(df_filtered["sample_segment"])
-    segments = df_filtered["sample_segment"].unique()
     df_filtered["subtype_from_match_title"] = (
         df_filtered["stitle"].str.extract(regex_subtype_pattern).astype("category")
     )
-    df_filtered["subtype_from_match_title"] = df_filtered["subtype_from_match_title"]
     logging.info(
         f"{sample_name} | Merging NCBI Influenza DB genome metadata with BLAST results on accession."
     )
@@ -293,7 +291,7 @@ def find_h_or_n_type(df_merge, seg):
     h_or_n = type_name[0]
     df_segment = df_merge.loc[seg, :]
     type_counts = df_segment.subtype.value_counts()
-    df_type_counts = type_counts.index.str.extract(h_or_n + r"(\d+)")
+    df_type_counts = type_counts.index.str.extract(h_or_n + r"(\d+)", flags=re.IGNORECASE)
     df_type_counts.columns = [type_name]
     df_type_counts["count"] = type_counts.values
     df_type_counts["subtype"] = type_counts.index
@@ -389,7 +387,6 @@ def report(flu_metadata, blast_results, excel_report, top, pident_threshold,
         f"Parsed Influenza metadata file into DataFrame with n={df_md.shape[0]} rows and n={df_md.shape[1]} columns. There are {unique_subtypes.size} unique subtypes. "
     )
     regex_subtype_pattern = r"\((H\d+N\d+|" + "|".join(list(unique_subtypes)) + r")\)"
-
     if threads > 1:
         pool = Pool(processes=threads)
         logging.info(


### PR DESCRIPTION
Add `flags=re.IGNORECASE` to handle subtype in lower case because there are 32 sequences in NCBI database have subtype in lower case
<!--
# CFIA-NCFAD/nf-flu pull request

Many thanks for contributing to CFIA-NCFAD/nf-flu!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/CFIA-NCFAD/nf-flu/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/CFIA-NCFAD/nf-flu/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on [the CFIA-NCFAD/nf-test-datasets repo](https://github.com/CFIA-NCFAD/nf-test-datasets/pull/new)
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
